### PR TITLE
Update PP and VNC-baseimage versions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+info.txt

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,17 @@
 # Pull base image.
 FROM jlesage/baseimage-gui:debian-12-v4
 
+# Target platform for the image (linux/amd64, linux/arm64)
+ARG TARGETARCH=amd64
+# Create list of architecture file names
+RUN case ${TARGETARCH} in \
+    amd64) ARCHITECTURE=linux.gtk.x86_64 ;; \
+    arm64) ARCHITECTURE=linux.gtk.aarch64 ;; \
+    *) echo "Unsupported architecture"; exit 1 ;; \
+    esac
+# Can be packaged with firefox, nextcloud, firefox-nextcloud, or none
+ARG PACKAGING=none
+
 ARG VERSION=0.70.3
 ENV ARCHIVE=https://github.com/buchen/portfolio/releases/download/${VERSION}/PortfolioPerformance-${VERSION}-linux.gtk.x86_64.tar.gz
 ENV APP_ICON_URL=https://www.portfolio-performance.info/images/logo.png
@@ -14,14 +25,60 @@ RUN apt-get update && apt-get install -y wget && \
 RUN \
     apt-get install -y \
     openjdk-17-jre \
-    libwebkit2gtk-4.1-0 \
-    firefox-esr \
-    xfce4 \
-    thunar \
-    tint2 \
-    gsimplecal && \
+    libwebkit2gtk-4.1-0 && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
+
+# If PACKAGING is set to firefox or firefox-nextcloud, install firefox-esr
+RUN if [ "$PACKAGING" = "firefox" ] || [ "$PACKAGING" = "firefox-nextcloud" ]; then \
+    apt-get update && apt-get install -y \
+    firefox-esr \
+    xfce4 \
+    xfce4-terminal \
+    thunar \
+    tint2 \
+    gsimplecal \
+    dbus \
+    dbus-x11 && \
+    apt-get clean && rm -rf /var/lib/apt/lists/*; \
+    fi
+
+# Prepare folder for a default Firefox profile and Create /etc/firefox/policies if it does not exist
+RUN if [ "$PACKAGING" = "firefox" ] || [ "$PACKAGING" = "firefox-nextcloud" ]; then \
+    mkdir -p /root/.mozilla/firefox && \
+    chmod -R 777 /root/.mozilla/firefox && \
+    mkdir -p /usr/lib/firefox-esr/distribution && \
+    echo '{"policies":{"OverrideFirstRunPage":"duckduckgo.com","OverridePostUpdatePage":"duckduckgo.com","ExtensionSettings":   {"uBlock0@raymondhill.net":{"installation_mode":"force_installed","install_url":"https://addons.mozilla.org/firefox/downloads/latest/  ublock-origin/latest.xpi"}}}}' > /usr/lib/firefox-esr/distribution/policies.json; \
+    fi
+
+
+# Remove items from tint2 config to prevent error messages on startup as the applications are not installed
+RUN if [ "$PACKAGING" = "firefox" ] || [ "$PACKAGING" = "firefox-nextcloud" ]; then \
+    sed -i '/launcher_item_app = tint2conf.desktop/d' /usr/share/tint2/vertical-neutral-icons.tint2rc && \
+    sed -i '/launcher_item_app = firefox.desktop/d' /usr/share/tint2/vertical-neutral-icons.tint2rc && \
+    sed -i '/launcher_item_app = iceweasel.desktop/d' /usr/share/tint2/vertical-neutral-icons.tint2rc && \
+    sed -i '/launcher_item_app = chromium-browser.desktop/d' /usr/share/tint2/vertical-neutral-icons.tint2rc && \
+    sed -i '/launcher_item_app = google-chrome.desktop/d' /usr/share/tint2/vertical-neutral-icons.tint2rc && \
+    sed -i '/launcher_item_app = x-terminal-emulator.desktop/d' /usr/share/tint2/vertical-neutral-icons.tint2rc && \
+    # Activate autohide for taskbar
+    sed -i 's/autohide = 0/autohide = 1/g' /usr/share/tint2/vertical-neutral-icons.tint2rc && \
+    sed -i 's/autohide_show_timeout = 0.3/autohide_show_timeout = 0.0/g' /usr/share/tint2/vertical-neutral-icons.tint2rc && \
+    sed -i 's/autohide_hide_timeout = 2/autohide_hide_timeout = 2/g' /usr/share/tint2/vertical-neutral-icons.tint2rc && \
+    sed -i 's/autohide_height = 2/autohide_height = 10/g' /usr/share/tint2/vertical-neutral-icons.tint2rc && \
+    # Add program items to taskbar
+    echo "launcher_item_app = /usr/share/applications/xfce4-file-manager.desktop" >> /usr/share/tint2/vertical-neutral-icons.tint2rc && \
+    echo "launcher_item_app = /usr/share/applications/firefox-esr.desktop" >> /usr/share/tint2/vertical-neutral-icons.tint2rc && \
+    echo "launcher_item_app = /usr/share/applications/xfce4-terminal.desktop" >> /usr/share/tint2/vertical-neutral-icons.tint2rc && \
+    # Change mouse actions for taskbar
+    sed -i 's/mouse_middle = close/mouse_middle = toggle/g' /usr/share/tint2/vertical-neutral-icons.tint2rc && \
+    sed -i 's/mouse_right = maximize_restore/mouse_right = close/g' /usr/share/tint2/vertical-neutral-icons.tint2rc; \
+    fi
+
+#RUN if [ "$PACKAGING" = "nextcloud" ] || [ "$PACKAGING" = "firefox-nextcloud" ]; then \
+#    apt-get update && apt-get install -y \
+#    nextcloud-desktop-cmd && \
+#    apt-get clean && rm -rf /var/lib/apt/lists/*; \
+#    fi
 
 RUN \
     # Write config entry for new data folder, cause otherwise pp would try to write in /dev which is not possible
@@ -36,33 +93,3 @@ ENV APP_NAME="Portfolio Performance"
 
 # Copy the start script.
 COPY rootfs/ /
-
-# Prepare folder for a default Firefox profile
-RUN mkdir -p /root/.mozilla/firefox && \
-    chmod -R 777 /root/.mozilla/firefox
-
-# Create /etc/firefox/policies if it does not exist
-RUN mkdir -p /usr/lib/firefox-esr/distribution && \
-    echo '{"policies":{"OverrideFirstRunPage":"duckduckgo.com","OverridePostUpdatePage":"duckduckgo.com","ExtensionSettings":{"uBlock0@raymondhill.net":{"installation_mode":"force_installed","install_url":"https://addons.mozilla.org/firefox/downloads/latest/ublock-origin/latest.xpi"}}}}' > /usr/lib/firefox-esr/distribution/policies.json
-
-# Remove items from tint2 config to prevent error messages on startup as the applications are not installed
-RUN sed -i '/launcher_item_app = tint2conf.desktop/d' /usr/share/tint2/vertical-neutral-icons.tint2rc && \
-    sed -i '/launcher_item_app = firefox.desktop/d' /usr/share/tint2/vertical-neutral-icons.tint2rc && \
-    sed -i '/launcher_item_app = iceweasel.desktop/d' /usr/share/tint2/vertical-neutral-icons.tint2rc && \
-    sed -i '/launcher_item_app = chromium-browser.desktop/d' /usr/share/tint2/vertical-neutral-icons.tint2rc && \
-    sed -i '/launcher_item_app = google-chrome.desktop/d' /usr/share/tint2/vertical-neutral-icons.tint2rc && \
-    sed -i '/launcher_item_app = x-terminal-emulator.desktop/d' /usr/share/tint2/vertical-neutral-icons.tint2rc && \
-    # Activate autohide for taskbar
-    sed -i 's/autohide = 0/autohide = 1/g' /usr/share/tint2/vertical-neutral-icons.tint2rc && \
-    sed -i 's/autohide_show_timeout = 0.3/autohide_show_timeout = 0.0/g' /usr/share/tint2/vertical-neutral-icons.tint2rc && \
-    sed -i 's/autohide_hide_timeout = 2/autohide_hide_timeout = 2/g' /usr/share/tint2/vertical-neutral-icons.tint2rc && \
-    sed -i 's/autohide_height = 2/autohide_height = 10/g' /usr/share/tint2/vertical-neutral-icons.tint2rc && \
-    # Add program items to taskbar
-    echo "launcher_item_app = /usr/share/applications/xfce4-file-manager.desktop" >> /usr/share/tint2/vertical-neutral-icons.tint2rc && \
-    echo "launcher_item_app = /usr/share/applications/firefox-esr.desktop" >> /usr/share/tint2/vertical-neutral-icons.tint2rc && \
-    # Change mouse actions for taskbar
-    sed -i 's/mouse_middle = close/mouse_middle = toggle/g' /usr/share/tint2/vertical-neutral-icons.tint2rc && \
-    sed -i 's/mouse_right = maximize_restore/mouse_right = close/g' /usr/share/tint2/vertical-neutral-icons.tint2rc
-
-# Install dbus to improve compatibility with firefox
-RUN apt-get update && apt-get install -y dbus dbus-x11 && apt-get clean && rm -rf /var/lib/apt/lists/*

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,20 +25,28 @@ RUN \
 	chmod -R 777 /opt/portfolio && \
     install_app_icon.sh "$APP_ICON_URL"
 
-# Copy the start script.
-COPY rootfs/ /
-
 # Set the name of the application.
 ENV APP_NAME="Portfolio Performance"
 
 RUN \
 apt-get update && apt-get install -y \
         xfce4 \
-        xfce4-terminal
+        xfce4-terminal \
+        tint2
 
 # RUN export DISPLAY=localhost:0.0
 RUN export DISPLAY=:0
 
+# Copy the start script.
+COPY rootfs/ /
+
 # Create a default Firefox profile
 RUN mkdir -p /root/.mozilla/firefox && \
-    firefox -CreateProfile "default /root/.mozilla/firefox/default" -headless
+    #chmod 777 /root/.mozilla/firefox && \
+    #firefox -CreateProfile "default /root/.mozilla/firefox/default" -headless \
+    chmod -R 777 /root/.mozilla/firefox
+
+# Set tint2 to show panel on the left side and vertically
+#RUN sed -i 's/panel_position = bottom/panel_position = left/g' /etc/xdg/tint2/tint2rc && \
+    #sed -i 's/panel_dock = 0/panel_dock = 1/g' /etc/xdg/tint2/tint2rc && \
+#    sed -i 's/panel_orientation = horizontal/panel_orientation = vertical/g' /etc/xdg/tint2/tint2rc

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # Pull base image.
-FROM jlesage/baseimage-gui:debian-11-v4.6.3
+FROM jlesage/baseimage-gui:debian-12-v4
 
-ENV VERSION 0.70.3
+ARG VERSION=0.70.3
 ENV ARCHIVE=https://github.com/buchen/portfolio/releases/download/${VERSION}/PortfolioPerformance-${VERSION}-linux.gtk.x86_64.tar.gz
 ENV APP_ICON_URL=https://www.portfolio-performance.info/images/logo.png
 	
@@ -14,7 +14,8 @@ RUN apt-get update && apt-get install -y wget && \
 RUN \
     apt-get install -y \
         openjdk-17-jre \
-        libwebkit2gtk-4.0-37 
+        libwebkit2gtk-4.1-0 \
+        firefox-esr
 
 RUN \
     # Write config entry for new data folder, cause otherwise pp would try to write in /dev which is not possible
@@ -29,3 +30,15 @@ COPY rootfs/ /
 
 # Set the name of the application.
 ENV APP_NAME="Portfolio Performance"
+
+RUN \
+apt-get update && apt-get install -y \
+        xfce4 \
+        xfce4-terminal
+
+# RUN export DISPLAY=localhost:0.0
+RUN export DISPLAY=:0
+
+# Create a default Firefox profile
+RUN mkdir -p /root/.mozilla/firefox && \
+    firefox -CreateProfile "default /root/.mozilla/firefox/default" -headless

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 FROM jlesage/baseimage-gui:debian-11-v4.6.3
 
 ENV VERSION 0.70.3
-ENV ARCHIVE https://github.com/buchen/portfolio/releases/download/${VERSION}/PortfolioPerformance-${VERSION}-linux.gtk.x86_64.tar.gz
+ENV ARCHIVE=https://github.com/buchen/portfolio/releases/download/${VERSION}/PortfolioPerformance-${VERSION}-linux.gtk.x86_64.tar.gz
 ENV APP_ICON_URL=https://www.portfolio-performance.info/images/logo.png
 	
 	

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # Pull base image.
-FROM jlesage/baseimage-gui:debian-11-v4.4.0
+FROM jlesage/baseimage-gui:debian-11-v4.6.3
 
-ENV VERSION 0.65.6
+ENV VERSION 0.70.3
 ENV ARCHIVE https://github.com/buchen/portfolio/releases/download/${VERSION}/PortfolioPerformance-${VERSION}-linux.gtk.x86_64.tar.gz
 ENV APP_ICON_URL=https://www.portfolio-performance.info/images/logo.png
 	

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,49 +4,65 @@ FROM jlesage/baseimage-gui:debian-12-v4
 ARG VERSION=0.70.3
 ENV ARCHIVE=https://github.com/buchen/portfolio/releases/download/${VERSION}/PortfolioPerformance-${VERSION}-linux.gtk.x86_64.tar.gz
 ENV APP_ICON_URL=https://www.portfolio-performance.info/images/logo.png
-	
-	
+
+
 RUN apt-get update && apt-get install -y wget && \
-	cd /opt && wget ${ARCHIVE} && tar xvzf PortfolioPerformance-${VERSION}-linux.gtk.x86_64.tar.gz && \
-	rm PortfolioPerformance-${VERSION}-linux.gtk.x86_64.tar.gz
+    cd /opt && wget ${ARCHIVE} && tar xvzf PortfolioPerformance-${VERSION}-linux.gtk.x86_64.tar.gz && \
+    rm PortfolioPerformance-${VERSION}-linux.gtk.x86_64.tar.gz
 
 # Install dependencies.
 RUN \
     apt-get install -y \
-        openjdk-17-jre \
-        libwebkit2gtk-4.1-0 \
-        firefox-esr
+    openjdk-17-jre \
+    libwebkit2gtk-4.1-0 \
+    firefox-esr \
+    xfce4 \
+    thunar \
+    tint2 \
+    gsimplecal && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
 
 RUN \
     # Write config entry for new data folder, cause otherwise pp would try to write in /dev which is not possible
     echo "-data\n/config/portfolio\n$(cat /opt/portfolio/PortfolioPerformance.ini)" > /opt/portfolio/PortfolioPerformance.ini && \
-	# Set initial language to english
+    # Set initial language to english
     echo "osgi.nl=en" >> /opt/portfolio/configuration/config.ini && \
-	chmod -R 777 /opt/portfolio && \
+    chmod -R 777 /opt/portfolio && \
     install_app_icon.sh "$APP_ICON_URL"
 
 # Set the name of the application.
-ENV APP_NAME="Portfolio Performance"
-
-RUN \
-apt-get update && apt-get install -y \
-        xfce4 \
-        xfce4-terminal \
-        tint2
-
-# RUN export DISPLAY=localhost:0.0
-RUN export DISPLAY=:0
+ENV APP_NAME="Portfolio Performance"        
 
 # Copy the start script.
 COPY rootfs/ /
 
-# Create a default Firefox profile
+# Prepare folder for a default Firefox profile
 RUN mkdir -p /root/.mozilla/firefox && \
-    #chmod 777 /root/.mozilla/firefox && \
-    #firefox -CreateProfile "default /root/.mozilla/firefox/default" -headless \
     chmod -R 777 /root/.mozilla/firefox
 
-# Set tint2 to show panel on the left side and vertically
-#RUN sed -i 's/panel_position = bottom/panel_position = left/g' /etc/xdg/tint2/tint2rc && \
-    #sed -i 's/panel_dock = 0/panel_dock = 1/g' /etc/xdg/tint2/tint2rc && \
-#    sed -i 's/panel_orientation = horizontal/panel_orientation = vertical/g' /etc/xdg/tint2/tint2rc
+# Create /etc/firefox/policies if it does not exist
+RUN mkdir -p /usr/lib/firefox-esr/distribution && \
+    echo '{"policies":{"OverrideFirstRunPage":"duckduckgo.com","OverridePostUpdatePage":"duckduckgo.com","ExtensionSettings":{"uBlock0@raymondhill.net":{"installation_mode":"force_installed","install_url":"https://addons.mozilla.org/firefox/downloads/latest/ublock-origin/latest.xpi"}}}}' > /usr/lib/firefox-esr/distribution/policies.json
+
+# Remove items from tint2 config to prevent error messages on startup as the applications are not installed
+RUN sed -i '/launcher_item_app = tint2conf.desktop/d' /usr/share/tint2/vertical-neutral-icons.tint2rc && \
+    sed -i '/launcher_item_app = firefox.desktop/d' /usr/share/tint2/vertical-neutral-icons.tint2rc && \
+    sed -i '/launcher_item_app = iceweasel.desktop/d' /usr/share/tint2/vertical-neutral-icons.tint2rc && \
+    sed -i '/launcher_item_app = chromium-browser.desktop/d' /usr/share/tint2/vertical-neutral-icons.tint2rc && \
+    sed -i '/launcher_item_app = google-chrome.desktop/d' /usr/share/tint2/vertical-neutral-icons.tint2rc && \
+    sed -i '/launcher_item_app = x-terminal-emulator.desktop/d' /usr/share/tint2/vertical-neutral-icons.tint2rc && \
+    # Activate autohide for taskbar
+    sed -i 's/autohide = 0/autohide = 1/g' /usr/share/tint2/vertical-neutral-icons.tint2rc && \
+    sed -i 's/autohide_show_timeout = 0.3/autohide_show_timeout = 0.0/g' /usr/share/tint2/vertical-neutral-icons.tint2rc && \
+    sed -i 's/autohide_hide_timeout = 2/autohide_hide_timeout = 2/g' /usr/share/tint2/vertical-neutral-icons.tint2rc && \
+    sed -i 's/autohide_height = 2/autohide_height = 10/g' /usr/share/tint2/vertical-neutral-icons.tint2rc && \
+    # Add program items to taskbar
+    echo "launcher_item_app = /usr/share/applications/xfce4-file-manager.desktop" >> /usr/share/tint2/vertical-neutral-icons.tint2rc && \
+    echo "launcher_item_app = /usr/share/applications/firefox-esr.desktop" >> /usr/share/tint2/vertical-neutral-icons.tint2rc && \
+    # Change mouse actions for taskbar
+    sed -i 's/mouse_middle = close/mouse_middle = toggle/g' /usr/share/tint2/vertical-neutral-icons.tint2rc && \
+    sed -i 's/mouse_right = maximize_restore/mouse_right = close/g' /usr/share/tint2/vertical-neutral-icons.tint2rc
+
+# Install dbus to improve compatibility with firefox
+RUN apt-get update && apt-get install -y dbus dbus-x11 && apt-get clean && rm -rf /var/lib/apt/lists/*

--- a/README.md
+++ b/README.md
@@ -55,18 +55,36 @@ be given the container.
 version: "3"
 services:
   portfolio-performance:
-    image: quallenbezwinger/portfolio-performance:0.7
+    image: nimra98/portfolio-performance:latest
     container_name: portfolio
     restart: unless-stopped
-    ports:
-      - 5800:5800
+    #ports: # this is not needed when using traefik
+    #  - 5800:5800
     volumes:
-      - /opt/docker-volumes/pp/config:/config
-      - /opt/docker-volumes/pp/workspace:/opt/portfolio/workspace
+      - /opt/docker-volumes/pp/config:/config # Change this to your desired configuration path
+      - /opt/docker-volumes/pp/workspace:/opt/portfolio/workspace # Change this to your desired workspace path
     environment:
       USER_ID: 1000
       GROUP_ID: 1000
       DISPLAY_WIDTH: 1920
       DISPLAY_HEIGHT: 1080
       TZ: "Europe/Berlin" 
+    labels:
+      - "traefik.enable=true"
+      - "traefik.docker.network=web-proxy"
+      - "traefik.http.routers.portfolio-performance-domain.rule=Host(`portfolio.domain.tld`)"
+      - "traefik.http.routers.portfolio-performance-domain.middlewares=sec, sec@file, gzip@file"
+      - "traefik.http.routers.portfolio-performance-domain.tls.options=intermediate@file"
+      - "traefik.http.routers.portfolio-performance-domain.tls.certresolver=httpchallenge"
+      # Declaring the user list
+      #
+      # Note: when used in docker-compose.yml all dollar signs in the hash need to be doubled for escaping.
+      # To create user:password pair, it's possible to use this command:
+      # echo $(htpasswd -nB user) | sed -e s/\\$/\\$\\$/g
+      #
+      # Also note that dollar signs should NOT be doubled when they not evaluated (e.g. Ansible docker_container module).
+      - "traefik.http.middlewares.sec.basicauth.users=user:xxxxxxxxxxxxxxxxxxxxxx" # Replace with your own user:password hash
+      - "traefik.http.services.portfolio.loadbalancer.server.port=5800" # 
+
+```
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,17 +1,33 @@
 version: "3"
 services:
   portfolio-performance:
-    image: quallenbezwinger/portfolio-performance:0.9
+    image: nimra98/portfolio-performance:latest
     container_name: portfolio
     restart: unless-stopped
-    ports:
-      - 5800:5800
+    #ports: # this is not needed when using traefik
+    #  - 5800:5800
     volumes:
-      - /opt/docker-volumes/pp/config:/config
-      - /opt/docker-volumes/pp/workspace:/opt/portfolio/workspace
+      - /opt/docker-volumes/pp/config:/config # Change this to your desired configuration path
+      - /opt/docker-volumes/pp/workspace:/opt/portfolio/workspace # Change this to your desired workspace path
     environment:
       USER_ID: 1000
       GROUP_ID: 1000
       DISPLAY_WIDTH: 1920
       DISPLAY_HEIGHT: 1080
       TZ: "Europe/Berlin" 
+    labels:
+      - "traefik.enable=true"
+      - "traefik.docker.network=web-proxy"
+      - "traefik.http.routers.portfolio-performance-domain.rule=Host(`portfolio.domain.tld`)"
+      - "traefik.http.routers.portfolio-performance-domain.middlewares=sec, sec@file, gzip@file"
+      - "traefik.http.routers.portfolio-performance-domain.tls.options=intermediate@file"
+      - "traefik.http.routers.portfolio-performance-domain.tls.certresolver=httpchallenge"
+      # Declaring the user list
+      #
+      # Note: when used in docker-compose.yml all dollar signs in the hash need to be doubled for escaping.
+      # To create user:password pair, it's possible to use this command:
+      # echo $(htpasswd -nB user) | sed -e s/\\$/\\$\\$/g
+      #
+      # Also note that dollar signs should NOT be doubled when they not evaluated (e.g. Ansible docker_container module).
+      - "traefik.http.middlewares.sec.basicauth.users=user:xxxxxxxxxxxxxxxxxxxxxx" # Replace with your own user:password hash
+      - "traefik.http.services.portfolio.loadbalancer.server.port=5800" # 

--- a/dockerhub.sh
+++ b/dockerhub.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
-docker push quallenbezwinger/portfolio-performance:0.9
+docker push quallenbezwinger/portfolio-performance:0.10
 docker push quallenbezwinger/portfolio-performance:latest

--- a/dockerhub.sh
+++ b/dockerhub.sh
@@ -1,4 +1,0 @@
-#!/bin/bash
-
-docker push quallenbezwinger/portfolio-performance:0.10
-docker push quallenbezwinger/portfolio-performance:latest

--- a/localImage.sh
+++ b/localImage.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
-docker build . -t quallenbezwinger/portfolio-performance:0.9
+docker build . -t quallenbezwinger/portfolio-performance:0.10
 docker build . -t quallenbezwinger/portfolio-performance:latest

--- a/localImage.sh
+++ b/localImage.sh
@@ -1,4 +1,0 @@
-#!/bin/bash
-
-docker build . -t quallenbezwinger/portfolio-performance:0.10
-docker build . -t quallenbezwinger/portfolio-performance:latest

--- a/makefile
+++ b/makefile
@@ -1,0 +1,49 @@
+.DEFAULT_GOAL := default
+
+# If makefile is called using sudo or as root, ensure that this user is also logged into dockerhub
+
+IMAGE ?= nimra98/portfolio-performance
+LATEST ?= false
+
+ifndef VERSION
+$(error VERSION is not set)
+endif
+
+.PHONY: build # Build the container image
+build:
+	@docker buildx create --use --name=crossplat --node=crossplat && \
+	if [ "$(LATEST)" = "true" ]; then \
+		docker buildx build \
+		--build-arg VERSION=$(VERSION) \
+		--output "type=docker,push=false" \
+		--tag $(IMAGE):$(VERSION) \
+		--tag $(IMAGE):latest \
+		. ; \
+	else \
+		docker buildx build \
+		--build-arg VERSION=$(VERSION) \
+		--output "type=docker,push=false" \
+		--tag $(IMAGE):$(VERSION) \
+		. ; \
+	fi
+	
+
+.PHONY: release # Push the image to the remote registry #linux/386,linux/amd64,linux/arm/v7,linux/arm64 
+release:
+	@docker buildx create --use --name=crossplat --node=crossplat && \
+	if [ "$(LATEST)" = "true" ]; then \
+		docker buildx build \
+		--build-arg VERSION=$(VERSION) \
+		--platform linux/amd64 \
+		--push \
+		--tag $(IMAGE):$(VERSION) \
+		--tag $(IMAGE):latest \
+		. ; \
+	else \
+		docker buildx build \
+		--build-arg VERSION=$(VERSION) \
+		-platform linux/amd64 \
+		--output "type=image,push=true" \
+		--tag $(IMAGE):$(VERSION) \
+		. ; \
+	fi

--- a/makefile
+++ b/makefile
@@ -9,12 +9,22 @@ ifndef VERSION
 $(error VERSION is not set)
 endif
 
+ifndef TARGETARCH
+$(error TARGETARCH is not set)
+endif
+
+ifndef PACKAGING
+$(error PACKAGING is not set)
+endif
+
 .PHONY: build # Build the container image
 build:
 	@docker buildx create --use --name=crossplat --node=crossplat && \
 	if [ "$(LATEST)" = "true" ]; then \
 		docker buildx build \
 		--build-arg VERSION=$(VERSION) \
+		--build-arg TARGETARCH=$(TARGETARCH) \
+		--build-arg PACKAGING=$(PACKAGING) \
 		--output "type=docker,push=false" \
 		--tag $(IMAGE):$(VERSION) \
 		--tag $(IMAGE):latest \

--- a/rootfs/startapp.sh
+++ b/rootfs/startapp.sh
@@ -7,11 +7,21 @@ start_pp() {
     exec /opt/portfolio/PortfolioPerformance > /config/log/pp_out.log 2> /config/log/pp_err.log
 }
 
-# Starten tint2 panel with preconfigured config
-exec tint2 -c /usr/share/tint2/vertical-neutral-icons.tint2rc &
+# Check if tint2 is installed
+if command -v tint2 >/dev/null 2>&1; then
+    # Start tint2 panel with preconfigured config
+    exec tint2 -c /usr/share/tint2/vertical-neutral-icons.tint2rc &
+    # Set DBUS_SESSION_BUS_ADDRESS (https://unix.stackexchange.com/a/647236)
+    export DBUS_SESSION_BUS_ADDRESS=`dbus-daemon --fork --config-file=/usr/share/dbus-1/session.conf --print-address`
+fi
 
-# Set DBUS env DBUS_SESSION_BUS_ADDRESS=unix:path=/run/user/1003/bus (https://unix.stackexchange.com/a/647236)
-export DBUS_SESSION_BUS_ADDRESS=`dbus-daemon --fork --config-file=/usr/share/dbus-1/session.conf --print-address`
+## if nextcloudcmd is installed, start it
+#if command -v nextcloudcmd >/dev/null 2>&1; then
+#    # Create nextcloud folder in /root
+#    mkdir -p /root/nextcloud
+#    # Start nextcloudcmd -s for silent
+#    exec nextcloudcmd --non-interactive -h -u $NEXTCLOUD_USER -p $NEXTCLOUD_PASSWORD --path $NEXTCLOUD_REMOTE_PATH /root/nextcloud #$NEXTCLOUD_URL 
+#fi
 
 # start portfolio performance
 start_pp

--- a/rootfs/startapp.sh
+++ b/rootfs/startapp.sh
@@ -7,5 +7,16 @@ start_pp() {
     exec /opt/portfolio/PortfolioPerformance > /config/log/pp_out.log 2> /config/log/pp_err.log
 }
 
+start_ff() {
+    # Create a default Firefox profile
+    #mkdir -p /root/.mozilla/firefox
+    #firefox -CreateProfile "default /root/.mozilla/firefox/default"
+    # Start firefox-esr
+    firefox-esr &
+}
+
+# start firefox
+start_ff
+
 # start portfolio performance
 start_pp

--- a/rootfs/startapp.sh
+++ b/rootfs/startapp.sh
@@ -7,19 +7,11 @@ start_pp() {
     exec /opt/portfolio/PortfolioPerformance > /config/log/pp_out.log 2> /config/log/pp_err.log
 }
 
-start_ff() {
-    # Create a default Firefox profile
-    #mkdir -p /root/.mozilla/firefox
-    firefox -CreateProfile "default /root/.mozilla/firefox/default"
-    # Start firefox-esr
-    firefox-esr &
-}
+# Starten tint2 panel with preconfigured config
+exec tint2 -c /usr/share/tint2/vertical-neutral-icons.tint2rc &
 
-# start firefox
-#start_ff
-
-# Starten Sie ein Panel (z.B. tint2)
-tint2 &
+# Set DBUS env DBUS_SESSION_BUS_ADDRESS=unix:path=/run/user/1003/bus (https://unix.stackexchange.com/a/647236)
+export DBUS_SESSION_BUS_ADDRESS=`dbus-daemon --fork --config-file=/usr/share/dbus-1/session.conf --print-address`
 
 # start portfolio performance
 start_pp

--- a/rootfs/startapp.sh
+++ b/rootfs/startapp.sh
@@ -10,13 +10,16 @@ start_pp() {
 start_ff() {
     # Create a default Firefox profile
     #mkdir -p /root/.mozilla/firefox
-    #firefox -CreateProfile "default /root/.mozilla/firefox/default"
+    firefox -CreateProfile "default /root/.mozilla/firefox/default"
     # Start firefox-esr
     firefox-esr &
 }
 
 # start firefox
-start_ff
+#start_ff
+
+# Starten Sie ein Panel (z.B. tint2)
+tint2 &
 
 # start portfolio performance
 start_pp

--- a/rootfs/startapp.sh
+++ b/rootfs/startapp.sh
@@ -1,13 +1,37 @@
 #!/bin/sh
 
-start_pp() {
-    #change to workdpace dir, so that file open dialog in pp will show up mounted dir in left menu
-    cd /opt/portfolio/workspace
-    #start application
-    exec /opt/portfolio/PortfolioPerformance > /config/log/pp_out.log 2> /config/log/pp_err.log
+echo '#!/bin/sh
+# Check if .lock file exists
+if [ -f /opt/portfolio/workspace/.sync.lock ]; then
+    echo "Sync already in progress"
+    return
+fi
+# Create .lock file to prevent multiple syncs
+touch /opt/portfolio/workspace/.sync.lock
+# Sync files to nextcloud
+exec nextcloudcmd --non-interactive -h -s -u $NEXTCLOUD_USER -p $NEXTCLOUD_PASSWORD --path "$NEXTCLOUD_REMOTE_PATH" /opt/portfolio/workspace/nextcloud $NEXTCLOUD_URL &
+# Wait for sync to finish
+wait $!
+# Remove .lock file
+rm /opt/portfolio/workspace/.sync.lock
+# Check if sync was successful
+if [ $? -eq 0 ]; then
+    echo "Sync successful"
+else
+    echo "Sync failed"
+fi' >> /tmp/start_sync.sh
+chmod +x /tmp/start_sync.sh
+
+
+autocheck_filesystem_inotify() {
+    inotifywait -m -r --exclude ".sync.*" -e modify,create,delete,move "/opt/portfolio/workspace/nextcloud" |
+    while read path action file; do
+        echo "The file '$file' at '$path' was $action"
+        /tmp/start_sync.sh
+    done
 }
 
-# Check if tint2 is installed
+# Check if tint2 is installed and start
 if command -v tint2 >/dev/null 2>&1; then
     # Start tint2 panel with preconfigured config
     exec tint2 -c /usr/share/tint2/vertical-neutral-icons.tint2rc &
@@ -15,13 +39,23 @@ if command -v tint2 >/dev/null 2>&1; then
     export DBUS_SESSION_BUS_ADDRESS=`dbus-daemon --fork --config-file=/usr/share/dbus-1/session.conf --print-address`
 fi
 
-## if nextcloudcmd is installed, start it
-#if command -v nextcloudcmd >/dev/null 2>&1; then
-#    # Create nextcloud folder in /root
-#    mkdir -p /root/nextcloud
-#    # Start nextcloudcmd -s for silent
-#    exec nextcloudcmd --non-interactive -h -u $NEXTCLOUD_USER -p $NEXTCLOUD_PASSWORD --path $NEXTCLOUD_REMOTE_PATH /root/nextcloud #$NEXTCLOUD_URL 
-#fi
+# if nextcloudcmd is installed, start it
+if command -v nextcloudcmd >/dev/null 2>&1; then
+    # Create nextcloud folder in /root
+    mkdir -p /opt/portfolio/workspace/nextcloud
+    /tmp/start_sync.sh
+    autocheck_filesystem_inotify &
+    # add cronjob to sync every 1 minute
+    #echo "*/1 * * * * /tmp/start_sync.sh" > /tmp/cronjob
+    #crontab /tmp/cronjob
+    #rm /tmp/cronjob
+fi
+
+# Set JAVA PATH variable for openjdk 17 jre
+export JAVA_HOME=/usr/lib/jvm/java-17-openjdk
 
 # start portfolio performance
-start_pp
+# change to workdpace dir, so that file open dialog in pp will show up mounted dir in left menu
+cd /opt/portfolio/workspace
+#start application
+exec /opt/portfolio/PortfolioPerformance > /config/log/pp_out.log 2> /config/log/pp_err.log


### PR DESCRIPTION
This PR updates the VNC baseimage to the current v4.6.3 and Portfolio Performance to 0.70.3.
A local test of the image did not suggest any issues or regressions.